### PR TITLE
Add models implementations

### DIFF
--- a/openl3/models.py
+++ b/openl3/models.py
@@ -1,3 +1,5 @@
+import os
+
 from kapre.time_frequency import Spectrogram, Melspectrogram
 from keras.layers import (
     Input, Conv2D, BatchNormalization, MaxPooling2D,
@@ -45,8 +47,7 @@ def get_embedding_model(input_repr, content_type, embedding_size):
 
     # Construct embedding model and load model weights
     m = MODELS[input_repr]()
-    m.load_weights(get_embedding_model_path(input_repr, content_type,
-                                            embedding_size))
+    m.load_weights(get_embedding_model_path(input_repr, content_type))
 
     # Pooling for final output embedding size
     pool_size = POOLINGS[input_repr][embedding_size]
@@ -56,7 +57,7 @@ def get_embedding_model(input_repr, content_type, embedding_size):
     return m
 
 
-def get_embedding_model_path(input_repr, content_type, embedding_size):
+def get_embedding_model_path(input_repr, content_type):
     """
     Returns the local path to the model weights file for the model
     with the given characteristics
@@ -67,8 +68,6 @@ def get_embedding_model_path(input_repr, content_type, embedding_size):
         Spectrogram representation used for model.
     content_type : "music" or "env"
         Type of content used to train embedding.
-    embedding_size : 6144 or 512
-        Embedding dimensionality.
 
     Returns
     -------
@@ -76,7 +75,9 @@ def get_embedding_model_path(input_repr, content_type, embedding_size):
         Path to given model object
     """
 
-    return 'openl3/openl3_audio_{}_{}.h5'.format(input_repr, content_type)
+    return os.path.join(os.path.dirname(__file__),
+                        'models',
+                        'openl3_audio_{}_{}.h5'.format(input_repr, content_type))
 
 
 def _construct_linear_audio_network():

--- a/openl3/models.py
+++ b/openl3/models.py
@@ -1,3 +1,28 @@
+from kapre.time_frequency import Spectrogram, Melspectrogram
+from keras.layers import (
+    Input, Conv2D, BatchNormalization, MaxPooling2D,
+    Flatten, Activation, Lambda
+)
+from keras.models import Model
+import keras.regularizers as regularizers
+
+
+POOLINGS = {
+    'linear': {
+        6144: (8, 8),
+        512: (32, 24),
+    },
+    'mel128': {
+        6144: (4, 8),
+        512: (16, 24),
+    },
+    'mel256': {
+        6144: (8, 8),
+        512: (32, 24),
+    }
+}
+
+
 def get_embedding_model(input_repr, content_type, embedding_size):
     """
     Returns a model with the given characteristics. Loads the model
@@ -16,9 +41,19 @@ def get_embedding_model(input_repr, content_type, embedding_size):
     -------
     model : keras.models.Model
         Model object.
-
     """
-    raise NotImplementedError()
+
+    # Construct embedding model and load model weights
+    m = MODELS[input_repr]()
+    m.load_weights(get_embedding_model_path(input_repr, content_type,
+                                            embedding_size))
+
+    # Pooling for final output embedding size
+    pool_size = POOLINGS[input_repr][embedding_size]
+    y_a = MaxPooling2D(pool_size=pool_size, padding='same')(m.output)
+    y_a = Flatten()(y_a)
+    m = Model(inputs=m.input, outputs=y_a)
+    return m
 
 
 def get_embedding_model_path(input_repr, content_type, embedding_size):
@@ -39,9 +74,9 @@ def get_embedding_model_path(input_repr, content_type, embedding_size):
     -------
     output_path : str
         Path to given model object
-
     """
-    raise NotImplementedError()
+
+    return 'openl3/openl3_audio_{}_{}.h5'.format(input_repr, content_type)
 
 
 def _construct_linear_audio_network():
@@ -53,9 +88,87 @@ def _construct_linear_audio_network():
     -------
     model : keras.models.Model
         Model object.
-
     """
-    raise NotImplementedError()
+
+    weight_decay = 1e-5
+    n_dft = 512
+    n_hop = 242
+    asr = 48000
+    audio_window_dur = 1
+
+    # INPUT
+    x_a = Input(shape=(1, asr * audio_window_dur), dtype='float32')
+
+    # SPECTROGRAM PREPROCESSING
+    # 257 x 199 x 1
+    y_a = Spectrogram(n_dft=n_dft, n_hop=n_hop, power_spectrogram=1.0,
+                      return_decibel_spectrogram=True, padding='valid')(x_a)
+    y_a = BatchNormalization()(y_a)
+
+    # CONV BLOCK 1
+    n_filter_a_1 = 64
+    filt_size_a_1 = (3, 3)
+    pool_size_a_1 = (2, 2)
+    y_a = Conv2D(n_filter_a_1, filt_size_a_1, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = Conv2D(n_filter_a_1, filt_size_a_1, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = MaxPooling2D(pool_size=pool_size_a_1, strides=2)(y_a)
+
+    # CONV BLOCK 2
+    n_filter_a_2 = 128
+    filt_size_a_2 = (3, 3)
+    pool_size_a_2 = (2, 2)
+    y_a = Conv2D(n_filter_a_2, filt_size_a_2, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = Conv2D(n_filter_a_2, filt_size_a_2, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = MaxPooling2D(pool_size=pool_size_a_2, strides=2)(y_a)
+
+    # CONV BLOCK 3
+    n_filter_a_3 = 256
+    filt_size_a_3 = (3, 3)
+    pool_size_a_3 = (2, 2)
+    y_a = Conv2D(n_filter_a_3, filt_size_a_3, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = Conv2D(n_filter_a_3, filt_size_a_3, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = MaxPooling2D(pool_size=pool_size_a_3, strides=2)(y_a)
+
+    # CONV BLOCK 4
+    n_filter_a_4 = 512
+    filt_size_a_4 = (3, 3)
+    pool_size_a_4 = (32, 24)
+    y_a = Conv2D(n_filter_a_4, filt_size_a_4, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = Conv2D(n_filter_a_4, filt_size_a_4,
+                 kernel_initializer='he_normal',
+                 name='audio_embedding_layer', padding='same',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+
+    m = Model(inputs=x_a, outputs=y_a)
+    return m
 
 
 def _construct_mel128_audio_network():
@@ -67,9 +180,89 @@ def _construct_mel128_audio_network():
     -------
     model : keras.models.Model
         Model object.
-
     """
-    raise NotImplementedError()
+
+    weight_decay = 1e-5
+    n_dft = 2048
+    n_mels = 128
+    n_hop = 242
+    asr = 48000
+    audio_window_dur = 1
+
+    # INPUT
+    x_a = Input(shape=(1, asr * audio_window_dur), dtype='float32')
+
+    # MELSPECTROGRAM PREPROCESSING
+    # 128 x 199 x 1
+    y_a = Melspectrogram(n_dft=n_dft, n_hop=n_hop, n_mels=n_mels,
+                      sr=asr, power_melgram=1.0, htk=True,
+                      return_decibel_melgram=True, padding='same')(x_a)
+    y_a = BatchNormalization()(y_a)
+
+    # CONV BLOCK 1
+    n_filter_a_1 = 64
+    filt_size_a_1 = (3, 3)
+    pool_size_a_1 = (2, 2)
+    y_a = Conv2D(n_filter_a_1, filt_size_a_1, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = Conv2D(n_filter_a_1, filt_size_a_1, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = MaxPooling2D(pool_size=pool_size_a_1, strides=2)(y_a)
+
+    # CONV BLOCK 2
+    n_filter_a_2 = 128
+    filt_size_a_2 = (3, 3)
+    pool_size_a_2 = (2, 2)
+    y_a = Conv2D(n_filter_a_2, filt_size_a_2, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = Conv2D(n_filter_a_2, filt_size_a_2, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = MaxPooling2D(pool_size=pool_size_a_2, strides=2)(y_a)
+
+    # CONV BLOCK 3
+    n_filter_a_3 = 256
+    filt_size_a_3 = (3, 3)
+    pool_size_a_3 = (2, 2)
+    y_a = Conv2D(n_filter_a_3, filt_size_a_3, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = Conv2D(n_filter_a_3, filt_size_a_3, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = MaxPooling2D(pool_size=pool_size_a_3, strides=2)(y_a)
+
+    # CONV BLOCK 4
+    n_filter_a_4 = 512
+    filt_size_a_4 = (3, 3)
+    pool_size_a_4 = (16, 24)
+    y_a = Conv2D(n_filter_a_4, filt_size_a_4, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = Conv2D(n_filter_a_4, filt_size_a_4,
+                 kernel_initializer='he_normal',
+                 name='audio_embedding_layer', padding='same',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+
+    m = Model(inputs=x_a, outputs=y_a)
+    return m
 
 
 def _construct_mel256_audio_network():
@@ -81,7 +274,93 @@ def _construct_mel256_audio_network():
     -------
     model : keras.models.Model
         Model object.
-
     """
-    raise NotImplementedError()
 
+    weight_decay = 1e-5
+    n_dft = 2048
+    n_mels = 256
+    n_hop = 242
+    asr = 48000
+    audio_window_dur = 1
+
+    # INPUT
+    x_a = Input(shape=(1, asr * audio_window_dur), dtype='float32')
+
+    # MELSPECTROGRAM PREPROCESSING
+    # 128 x 199 x 1
+    y_a = Melspectrogram(n_dft=n_dft, n_hop=n_hop, n_mels=n_mels,
+                      sr=asr, power_melgram=1.0, htk=True, # n_win=n_win,
+                      return_decibel_melgram=True, padding='same')(x_a)
+    y_a = BatchNormalization()(y_a)
+
+    # CONV BLOCK 1
+    n_filter_a_1 = 64
+    filt_size_a_1 = (3, 3)
+    pool_size_a_1 = (2, 2)
+    y_a = Conv2D(n_filter_a_1, filt_size_a_1, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = Conv2D(n_filter_a_1, filt_size_a_1, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = MaxPooling2D(pool_size=pool_size_a_1, strides=2)(y_a)
+
+    # CONV BLOCK 2
+    n_filter_a_2 = 128
+    filt_size_a_2 = (3, 3)
+    pool_size_a_2 = (2, 2)
+    y_a = Conv2D(n_filter_a_2, filt_size_a_2, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = Conv2D(n_filter_a_2, filt_size_a_2, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = MaxPooling2D(pool_size=pool_size_a_2, strides=2)(y_a)
+
+    # CONV BLOCK 3
+    n_filter_a_3 = 256
+    filt_size_a_3 = (3, 3)
+    pool_size_a_3 = (2, 2)
+    y_a = Conv2D(n_filter_a_3, filt_size_a_3, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = Conv2D(n_filter_a_3, filt_size_a_3, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = MaxPooling2D(pool_size=pool_size_a_3, strides=2)(y_a)
+
+    # CONV BLOCK 4
+    n_filter_a_4 = 512
+    filt_size_a_4 = (3, 3)
+    pool_size_a_4 = (32, 24)
+    y_a = Conv2D(n_filter_a_4, filt_size_a_4, padding='same',
+                 kernel_initializer='he_normal',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Activation('relu')(y_a)
+    y_a = Conv2D(n_filter_a_4, filt_size_a_4,
+                 kernel_initializer='he_normal',
+                 name='audio_embedding_layer', padding='same',
+                 kernel_regularizer=regularizers.l2(weight_decay))(y_a)
+
+    m = Model(inputs=x_a, outputs=y_a)
+    return m
+
+
+MODELS = {
+    'linear': _construct_linear_audio_network,
+    'mel128': _construct_mel128_audio_network,
+    'mel256': _construct_mel256_audio_network
+}

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if len(sys.argv) > 1 and sys.argv[1] == 'sdist':
 else:
     # in all other cases, decompress the weights file if necessary
     for weight_file in weight_files:
-        weight_path = os.path.join('openl3', weight_file)
+        weight_path = os.path.join('openl3', 'models', weight_file)
         if not os.path.isfile(weight_path):
             compressed_file = weight_file + '.gz'
             compressed_path = os.path.join('openl3', compressed_file)

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,15 @@ if len(sys.argv) > 1 and sys.argv[1] == 'sdist':
     # exclude the weight files in sdist
     weight_files = []
 else:
+    root_path = os.path.join('openl3', 'models')
+    if not os.path.exists(root_path):
+        os.makedirs(root_path)
     # in all other cases, decompress the weights file if necessary
     for weight_file in weight_files:
-        weight_path = os.path.join('openl3', 'models', weight_file)
+        weight_path = os.path.join(root_path, weight_file)
         if not os.path.isfile(weight_path):
             compressed_file = weight_file + '.gz'
-            compressed_path = os.path.join('openl3', compressed_file)
+            compressed_path = os.path.join(root_path, compressed_file)
             if not os.path.isfile(compressed_file):
                 print('Downloading weight file {} ...'.format(compressed_file))
                 urlretrieve(base_url + compressed_file, compressed_path)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,11 @@
+from openl3.models import get_embedding_model, get_embedding_model_path
+
+
+def test_get_embedding_model_path():
+    for input_repr in ('linear', 'mel128', 'mel256'):
+        for content_type in ('music', 'env'):
+            for embedding_size in (512, 6144):
+                model_path = get_embedding_model_path(input_repr=input_repr,
+                                                      content_type=content_type,
+                                                      embedding_size=embedding_size)
+                assert model_path == 'openl3/openl3_audio_{}_{}.h5'.format(input_repr, content_type)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,10 +2,58 @@ from openl3.models import get_embedding_model, get_embedding_model_path
 
 
 def test_get_embedding_model_path():
-    for input_repr in ('linear', 'mel128', 'mel256'):
-        for content_type in ('music', 'env'):
-            for embedding_size in (512, 6144):
-                model_path = get_embedding_model_path(input_repr=input_repr,
-                                                      content_type=content_type,
-                                                      embedding_size=embedding_size)
-                assert model_path == 'openl3/openl3_audio_{}_{}.h5'.format(input_repr, content_type)
+    embedding_model_path = get_embedding_model_path('linear', 'music')
+    assert embedding_model_path == 'openl3/models/openl3_audio_linear_music.h5'
+
+    embedding_model_path = get_embedding_model_path('linear', 'env')
+    assert embedding_model_path == 'openl3/models/openl3_audio_linear_env.h5'
+
+    embedding_model_path = get_embedding_model_path('mel128', 'music')
+    assert embedding_model_path == 'openl3/models/openl3_audio_mel128_music.h5'
+
+    embedding_model_path = get_embedding_model_path('mel128', 'env')
+    assert embedding_model_path == 'openl3/models/openl3_audio_mel128_music.h5'
+
+    embedding_model_path = get_embedding_model_path('mel256', 'music')
+    assert embedding_model_path == 'openl3/models/openl3_audio_mel256_env.h5'
+
+    embedding_model_path = get_embedding_model_path('mel256', 'env')
+    assert embedding_model_path == 'openl3/models/openl3_audio_mel256_music.h5'
+
+
+def test_get_embedding_model():
+    m = get_embedding_model('linear', 'music', 6144)
+    assert m.output_shape[1] == 6144
+
+    m = get_embedding_model('linear', 'music', 512)
+    assert m.output_shape[1] == 512
+
+    m = get_embedding_model('linear', 'env', 6144)
+    assert m.output_shape[1] == 6144
+
+    m = get_embedding_model('linear', 'env', 512)
+    assert m.output_shape[1] == 512
+
+    m = get_embedding_model('mel128', 'music', 6144)
+    assert m.output_shape[1] == 6144
+
+    m = get_embedding_model('mel128', 'music', 512)
+    assert m.output_shape[1] == 512
+
+    m = get_embedding_model('mel128', 'env', 6144)
+    assert m.output_shape[1] == 6144
+
+    m = get_embedding_model('mel128', 'env', 512)
+    assert m.output_shape[1] == 512
+
+    m = get_embedding_model('mel256', 'music', 6144)
+    assert m.output_shape[1] == 6144
+
+    m = get_embedding_model('mel256', 'music', 512)
+    assert m.output_shape[1] == 512
+
+    m = get_embedding_model('mel256', 'env', 6144)
+    assert m.output_shape[1] == 6144
+
+    m = get_embedding_model('mel256', 'env', 512)
+    assert m.output_shape[1] == 512

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,13 +12,13 @@ def test_get_embedding_model_path():
     assert '/'.join(embedding_model_path.split('/')[-3:]) == 'openl3/models/openl3_audio_mel128_music.h5'
 
     embedding_model_path = get_embedding_model_path('mel128', 'env')
-    assert '/'.join(embedding_model_path.split('/')[-3:]) == 'openl3/models/openl3_audio_mel128_music.h5'
+    assert '/'.join(embedding_model_path.split('/')[-3:]) == 'openl3/models/openl3_audio_mel128_env.h5'
 
     embedding_model_path = get_embedding_model_path('mel256', 'music')
-    assert '/'.join(embedding_model_path.split('/')[-3:]) == 'openl3/models/openl3_audio_mel256_env.h5'
+    assert '/'.join(embedding_model_path.split('/')[-3:]) == 'openl3/models/openl3_audio_mel256_music.h5'
 
     embedding_model_path = get_embedding_model_path('mel256', 'env')
-    assert '/'.join(embedding_model_path.split('/')[-3:]) == 'openl3/models/openl3_audio_mel256_music.h5'
+    assert '/'.join(embedding_model_path.split('/')[-3:]) == 'openl3/models/openl3_audio_mel256_env.h5'
 
 
 def test_get_embedding_model():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,22 +3,22 @@ from openl3.models import get_embedding_model, get_embedding_model_path
 
 def test_get_embedding_model_path():
     embedding_model_path = get_embedding_model_path('linear', 'music')
-    assert embedding_model_path == 'openl3/models/openl3_audio_linear_music.h5'
+    assert '/'.join(embedding_model_path.split('/')[-3:]) == 'openl3/models/openl3_audio_linear_music.h5'
 
     embedding_model_path = get_embedding_model_path('linear', 'env')
-    assert embedding_model_path == 'openl3/models/openl3_audio_linear_env.h5'
+    assert '/'.join(embedding_model_path.split('/')[-3:]) == 'openl3/models/openl3_audio_linear_env.h5'
 
     embedding_model_path = get_embedding_model_path('mel128', 'music')
-    assert embedding_model_path == 'openl3/models/openl3_audio_mel128_music.h5'
+    assert '/'.join(embedding_model_path.split('/')[-3:]) == 'openl3/models/openl3_audio_mel128_music.h5'
 
     embedding_model_path = get_embedding_model_path('mel128', 'env')
-    assert embedding_model_path == 'openl3/models/openl3_audio_mel128_music.h5'
+    assert '/'.join(embedding_model_path.split('/')[-3:]) == 'openl3/models/openl3_audio_mel128_music.h5'
 
     embedding_model_path = get_embedding_model_path('mel256', 'music')
-    assert embedding_model_path == 'openl3/models/openl3_audio_mel256_env.h5'
+    assert '/'.join(embedding_model_path.split('/')[-3:]) == 'openl3/models/openl3_audio_mel256_env.h5'
 
     embedding_model_path = get_embedding_model_path('mel256', 'env')
-    assert embedding_model_path == 'openl3/models/openl3_audio_mel256_music.h5'
+    assert '/'.join(embedding_model_path.split('/')[-3:]) == 'openl3/models/openl3_audio_mel256_music.h5'
 
 
 def test_get_embedding_model():


### PR DESCRIPTION
Adding model implementations to models.py file. I have a couple questions accessing the model files.

In `get_embedding_model_path` function, what is the best way to access the model files in the relative directory, assuming that the setup.py file will download those files in the same openl3 folders?

How to test these function with the actual model weights file? Should I add those model weight files also to test folder so we can use for test? or it is sufficient that we only test the model architecture without the actual weights?

/cc @jtcramer @justinsalamon 