### PR TITLE
gitignore openl3/models/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ docs/_build/*
 thumbs.db
 
 *.egg-info
+
+models/*

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ thumbs.db
 
 *.egg-info
 
-models/*
+openl3/models/*


### PR DESCRIPTION
installing with `pip install -e .` creates a new folder `models` in `openl3` in which the Open L3 models are downloaded in HDF5 format
AFAIU these models should remain on the `models` branch and never be committed to the `master`  branch
this PR `gitignore`s the `models` subfolder to avoid this issue