### PR TITLE
Model loading

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,12 @@
 Changelog
 ---------
 
+v0.2.0
+~~~~~~
+- Update embedding models with ones that have been trained with the kapre bug fixed.
+- Allow loaded models to be passed in and used in `process_file` and `get_embedding`.
+- Rename `get_embedding_model` to `load_embedding_model`.
+
 v0.1.1
 ~~~~~~
 - Update kapre to fix issue with dynamic range normalization for decibel computation when computing spectrograms.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -88,6 +88,8 @@ By default, the corresponding model file is loaded every time this function is c
     model = openl3.models.load_embedding_model(input_repr="mel256", content_type="music", embedding_size=6144)
     emb, ts = openl3.get_embedding(audio, sr, model=model)
 
+Note that if a model is provided, then the keyword arguments `input_repr`, `content_type` and `embedding_size` for the function `get_embedding` will be ignored.
+
 To compute embeddings for an audio file and save them locally, you can use code like the following:
 
 .. code-block:: python
@@ -125,6 +127,9 @@ Like before, you can also load the model before processing the file so that load
 
     data = np.load('/path/to/file.npz')
     emb, ts = data['embedding'], data['timestamps']
+
+
+Again, note that if a model is provided, then the keyword arguments `input_repr`, `content_type` and `embedding_size` for the function `process_file` will be ignored.
 
 Using the CLI
 -------------

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -85,7 +85,7 @@ By default, the corresponding model file is loaded every time this function is c
 
     import openl3
     import soundfile as sf
-    model = openl3.models.get_embedding_model(input_repr="mel256", content_type="music", embedding_size=6144)
+    model = openl3.models.load_embedding_model(input_repr="mel256", content_type="music", embedding_size=6144)
     emb, ts = openl3.get_embedding(audio, sr, model=model)
 
 To compute embeddings for an audio file and save them locally, you can use code like the following:
@@ -113,7 +113,7 @@ Like before, you can also load the model before processing the file so that load
     import openl3
     import numpy as np
 
-    model = openl3.models.get_embedding_model(input_repr="mel256", content_type="music", embedding_size=6144)
+    model = openl3.models.load_embedding_model(input_repr="mel256", content_type="music", embedding_size=6144)
 
     audio_filepath = '/path/to/file.wav'
     # Saves the file to '/path/to/file.npz'

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -85,7 +85,7 @@ By default, the corresponding model file is loaded every time this function is c
 
     import openl3
     import soundfile as sf
-    model = openl3.get_embedding_model(input_repr="mel256", content_type="music", embedding_size=6144)
+    model = openl3.models.get_embedding_model(input_repr="mel256", content_type="music", embedding_size=6144)
     emb, ts = openl3.get_embedding(audio, sr, model=model)
 
 To compute embeddings for an audio file and save them locally, you can use code like the following:
@@ -113,7 +113,7 @@ Like before, you can also load the model before processing the file so that load
     import openl3
     import numpy as np
 
-    model = openl3.get_embedding_model(input_repr="mel256", content_type="music", embedding_size=6144)
+    model = openl3.models.get_embedding_model(input_repr="mel256", content_type="music", embedding_size=6144)
 
     audio_filepath = '/path/to/file.wav'
     # Saves the file to '/path/to/file.npz'

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -79,6 +79,15 @@ model verbosity to either 0 or 1:
     import soundfile as sf
     emb, ts = openl3.get_embedding(audio, sr, verbose=0)
 
+By default, the corresponding model file is loaded every time this function is called. If you want to load the model only once when computing multiple embeddings, you can run:
+
+.. code-block:: python
+
+    import openl3
+    import soundfile as sf
+    model = openl3.get_embedding_model(input_repr="mel256", content_type="music", embedding_size=6144)
+    emb, ts = openl3.get_embedding(audio, sr, model=model)
+
 To compute embeddings for an audio file and save them locally, you can use code like the following:
 
 .. code-block:: python
@@ -93,6 +102,26 @@ To compute embeddings for an audio file and save them locally, you can use code 
     openl3.process_file(audio_filepath, output_dir='/different/dir', suffix='suffix')
     # Saves the file to '/path/to/file_suffix.npz'
     openl3.process_file(audio_filepath, suffix='suffix')
+
+    data = np.load('/path/to/file.npz')
+    emb, ts = data['embedding'], data['timestamps']
+
+Like before, you can also load the model before processing the file so that loading the model only happens once:
+
+.. code-block:: python
+
+    import openl3
+    import numpy as np
+
+    model = openl3.get_embedding_model(input_repr="mel256", content_type="music", embedding_size=6144)
+
+    audio_filepath = '/path/to/file.wav'
+    # Saves the file to '/path/to/file.npz'
+    openl3.process_file(audio_filepath, model=model)
+    # Saves the file to `/different/dir/file.npz`
+    openl3.process_file(audio_filepath, output_dir='/different/dir', suffix='suffix' model=model)
+    # Saves the file to '/path/to/file_suffix.npz'
+    openl3.process_file(audio_filepath, suffix='suffix', model=model)
 
     data = np.load('/path/to/file.npz')
     emb, ts = data['embedding'], data['timestamps']

--- a/openl3/cli.py
+++ b/openl3/cli.py
@@ -83,6 +83,9 @@ def run(inputs, output_dir=None, suffix=None, input_repr="mel256", content_type=
         print('openl3: No WAV files found in {}. Aborting.'.format(str(inputs)))
         sys.exit(-1)
 
+    # Load model
+    model = get_embedding_model(input_repr, content_type, embedding_size)
+
     # Process all files in the arguments
     for filepath in file_list:
         if verbose:
@@ -90,9 +93,7 @@ def run(inputs, output_dir=None, suffix=None, input_repr="mel256", content_type=
         process_file(filepath,
                      output_dir=output_dir,
                      suffix=suffix,
-                     input_repr=input_repr,
-                     content_type=content_type,
-                     embedding_size=embedding_size,
+                     model=model,
                      center=center,
                      hop_size=hop_size,
                      verbose=verbose)

--- a/openl3/cli.py
+++ b/openl3/cli.py
@@ -3,6 +3,7 @@ import os
 import sys
 from openl3.openl3_exceptions import OpenL3Error
 from openl3 import process_file
+from openl3.models import get_embedding_model
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, ArgumentTypeError
 from collections import Iterable
 from six import string_types

--- a/openl3/cli.py
+++ b/openl3/cli.py
@@ -3,7 +3,7 @@ import os
 import sys
 from openl3.openl3_exceptions import OpenL3Error
 from openl3 import process_file
-from openl3.models import get_embedding_model
+from openl3.models import load_embedding_model
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, ArgumentTypeError
 from collections import Iterable
 from six import string_types
@@ -85,7 +85,7 @@ def run(inputs, output_dir=None, suffix=None, input_repr="mel256", content_type=
         sys.exit(-1)
 
     # Load model
-    model = get_embedding_model(input_repr, content_type, embedding_size)
+    model = load_embedding_model(input_repr, content_type, embedding_size)
 
     # Process all files in the arguments
     for filepath in file_list:

--- a/openl3/core.py
+++ b/openl3/core.py
@@ -47,15 +47,20 @@ def get_embedding(audio, sr, model=None, input_repr="mel256",
     sr : int
         Sampling rate, if not 48kHz will audio will be resampled.
     model : keras.models.Model or None
-        Loaded model object. If None, model will be loaded using
+        Loaded model object. If a model is provided, then `input_repr`,
+        `content_type`, and `embedding_size` will be ignored.
+        If None is provided, the model will be loaded using
         the provided values of `input_repr`, `content_type` and
         `embedding_size`.
     input_repr : "linear", "mel128", or "mel256"
-        Spectrogram representation used for model.
+        Spectrogram representation used for model. Ignored if `model` is
+        a valid Keras model.
     content_type : "music" or "env"
-        Type of content used to train embedding.
+        Type of content used to train embedding. Ignored if `model` is
+        a valid Keras model.
     embedding_size : 6144 or 512
-        Embedding dimensionality.
+        Embedding dimensionality. Ignored if `model` is a valid
+        Keras model.
     center : boolean
         If True, pads beginning of signal so timestamps correspond
         to center of window.
@@ -164,15 +169,20 @@ def process_file(filepath, output_dir=None, suffix=None, model=None,
         String to be appended to the output filename, i.e. <base filename>_<suffix>.npz.
         If None, then no suffix will be added, i.e. <base filename>.npz.
     model : keras.models.Model or None
-        Loaded model object. If None, model will be loaded using
+        Loaded model object. If a model is provided, then `input_repr`,
+        `content_type`, and `embedding_size` will be ignored.
+        If None is provided, the model will be loaded using
         the provided values of `input_repr`, `content_type` and
         `embedding_size`.
     input_repr : "linear", "mel128", or "mel256"
-        Spectrogram representation used for model.
+        Spectrogram representation used for model. Ignored if `model` is
+        a valid Keras model.
     content_type : "music" or "env"
-        Type of content used to train embedding.
+        Type of content used to train embedding. Ignored if `model` is
+        a valid Keras model.
     embedding_size : 6144 or 512
-        Embedding dimensionality.
+        Embedding dimensionality. Ignored if `model` is a valid
+        Keras model.
     center : boolean
         If True, pads beginning of signal so timestamps correspond
         to center of window.

--- a/openl3/core.py
+++ b/openl3/core.py
@@ -6,7 +6,7 @@ import numpy as np
 from numbers import Real
 import warnings
 import keras
-from .models import get_embedding_model
+from .models import load_embedding_model
 from .openl3_exceptions import OpenL3Error
 from .openl3_warnings import OpenL3Warning
 
@@ -114,7 +114,7 @@ def get_embedding(audio, sr, model=None, input_repr="mel256",
 
     # Get embedding model
     if model is None:
-        model = get_embedding_model(input_repr, content_type, embedding_size)
+        model = load_embedding_model(input_repr, content_type, embedding_size)
 
     audio_len = audio.size
     frame_len = TARGET_SR

--- a/openl3/core.py
+++ b/openl3/core.py
@@ -5,6 +5,7 @@ import soundfile as sf
 import numpy as np
 from numbers import Real
 import warnings
+import keras
 from .models import get_embedding_model
 from .openl3_exceptions import OpenL3Error
 from .openl3_warnings import OpenL3Warning
@@ -33,7 +34,8 @@ def _pad_audio(audio, frame_len, hop_len):
     return audio
 
 
-def get_embedding(audio, sr, input_repr="mel256", content_type="music", embedding_size=6144,
+def get_embedding(audio, sr, model=None, input_repr="mel256",
+                  content_type="music", embedding_size=6144,
                   center=True, hop_size=0.1, verbose=1):
     """
     Computes and returns L3 embedding for given audio data
@@ -44,6 +46,10 @@ def get_embedding(audio, sr, input_repr="mel256", content_type="music", embeddin
         1D numpy array of audio data.
     sr : int
         Sampling rate, if not 48kHz will audio will be resampled.
+    model : keras.models.Model or None
+        Loaded model object. If None, model will be loaded using
+        the provided values of `input_repr`, `content_type` and
+        `embedding_size`.
     input_repr : "linear", "mel128", or "mel256"
         Spectrogram representation used for model.
     content_type : "music" or "env"
@@ -72,6 +78,10 @@ def get_embedding(audio, sr, input_repr="mel256", content_type="music", embeddin
     # Warn user if audio is all zero
     if np.all(audio == 0):
         warnings.warn('Provided audio is all zeros', OpenL3Warning)
+
+    if model is not None and not isinstance(model, keras.models.Model):
+        raise OpenL3Error('Invalid model provided. Must be of type keras.model.Models'
+                          ' but got {}'.format(str(type(model))))
 
     if str(input_repr) not in ("linear", "mel128", "mel256"):
         raise OpenL3Error('Invalid input representation "{}"'.format(input_repr))
@@ -103,7 +113,8 @@ def get_embedding(audio, sr, input_repr="mel256", content_type="music", embeddin
         audio = resampy.resample(audio, sr_orig=sr, sr_new=TARGET_SR, filter='kaiser_best')
 
     # Get embedding model
-    model = get_embedding_model(input_repr, content_type, embedding_size)
+    if model is None:
+        model = get_embedding_model(input_repr, content_type, embedding_size)
 
     audio_len = audio.size
     frame_len = TARGET_SR
@@ -136,7 +147,8 @@ def get_embedding(audio, sr, input_repr="mel256", content_type="music", embeddin
     return embedding, ts
 
 
-def process_file(filepath, output_dir=None, suffix=None, input_repr="mel256", content_type="music",
+def process_file(filepath, output_dir=None, suffix=None, model=None,
+                 input_repr="mel256", content_type="music",
                  embedding_size=6144, center=True, hop_size=0.1, verbose=True):
     """
     Computes and saves L3 embedding for given audio file
@@ -151,6 +163,10 @@ def process_file(filepath, output_dir=None, suffix=None, input_repr="mel256", co
     suffix : str or None
         String to be appended to the output filename, i.e. <base filename>_<suffix>.npz.
         If None, then no suffix will be added, i.e. <base filename>.npz.
+    model : keras.models.Model or None
+        Loaded model object. If None, model will be loaded using
+        the provided values of `input_repr`, `content_type` and
+        `embedding_size`.
     input_repr : "linear", "mel128", or "mel256"
         Spectrogram representation used for model.
     content_type : "music" or "env"
@@ -182,8 +198,10 @@ def process_file(filepath, output_dir=None, suffix=None, input_repr="mel256", co
 
     output_path = get_output_path(filepath, suffix + ".npz", output_dir=output_dir)
 
-    embedding, ts = get_embedding(audio, sr, input_repr=input_repr, content_type=content_type,
-        embedding_size=embedding_size, center=center, hop_size=hop_size, verbose=1 if verbose else 0)
+    embedding, ts = get_embedding(audio, sr, model=model, input_repr=input_repr,
+                                  content_type=content_type,
+                                  embedding_size=embedding_size, center=center,
+                                  hop_size=hop_size, verbose=1 if verbose else 0)
 
     np.savez(output_path, embedding=embedding, timestamps=ts)
     assert os.path.exists(output_path)

--- a/openl3/models.py
+++ b/openl3/models.py
@@ -29,7 +29,7 @@ POOLINGS = {
 }
 
 
-def get_embedding_model(input_repr, content_type, embedding_size):
+def load_embedding_model(input_repr, content_type, embedding_size):
     """
     Returns a model with the given characteristics. Loads the model
     if the model has not been loaded yet.
@@ -54,7 +54,7 @@ def get_embedding_model(input_repr, content_type, embedding_size):
         warnings.simplefilter("ignore")
         m = MODELS[input_repr]()
 
-    m.load_weights(get_embedding_model_path(input_repr, content_type))
+    m.load_weights(load_embedding_model_path(input_repr, content_type))
 
     # Pooling for final output embedding size
     pool_size = POOLINGS[input_repr][embedding_size]
@@ -64,7 +64,7 @@ def get_embedding_model(input_repr, content_type, embedding_size):
     return m
 
 
-def get_embedding_model_path(input_repr, content_type):
+def load_embedding_model_path(input_repr, content_type):
     """
     Returns the local path to the model weights file for the model
     with the given characteristics

--- a/openl3/version.py
+++ b/openl3/version.py
@@ -1,2 +1,2 @@
-short_version = '0.1'
-version = '0.1.2rc0'
+short_version = '0.2'
+version = '0.2.0rc0'

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         'Documentation': 'https://readthedocs.org/projects/openl3/'
     },
     install_requires=[
-        'keras==2.0.9',
+        'keras>=2.0.9',
         'numpy>=1.13.0',
         'scipy>=0.19.1',
         'kapre>=0.1.4',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ module_dir = 'openl3'
 modalities = ['audio', 'image']
 input_reprs = ['linear', 'mel128', 'mel256']
 content_type = ['music', 'env']
-model_version_str = 'v0_1_2'
+model_version_str = 'v0_2_0'
 weight_files = ['openl3_{}_{}_{}.h5'.format(*tup)
                 for tup in product(modalities, input_reprs, content_type)]
 base_url = 'https://github.com/marl/openl3/raw/models/'

--- a/tests/notebooks/generate_openl3_regression_data.ipynb
+++ b/tests/notebooks/generate_openl3_regression_data.ipynb
@@ -209,7 +209,7 @@
    "outputs": [],
    "source": [
     "# path to store output embeddings\n",
-    "output_dir = os.path.expanduser('~/Downloads/')"
+    "output_dir = os.path.expanduser('~/openl3_output/')"
    ]
   },
   {
@@ -221,9 +221,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /beegfs/jtc440/miniconda3/lib/python3.6/site-packages/keras/backend/tensorflow_backend.py:1204: calling reduce_max (from tensorflow.python.ops.math_ops) with keep_dims is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "keep_dims is deprecated, use keepdims instead\n",
+      "WARNING:tensorflow:From /beegfs/jtc440/miniconda3/lib/python3.6/site-packages/keras/backend/tensorflow_backend.py:1238: calling reduce_sum (from tensorflow.python.ops.math_ops) with keep_dims is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "keep_dims is deprecated, use keepdims instead\n",
+      "WARNING:tensorflow:From /beegfs/jtc440/miniconda3/lib/python3.6/site-packages/keras/backend/tensorflow_backend.py:1255: calling reduce_prod (from tensorflow.python.ops.math_ops) with keep_dims is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "keep_dims is deprecated, use keepdims instead\n"
+     ]
+    }
+   ],
    "source": [
     "# compute mel256/music/6144 regression embedding\n",
     "suffix=None\n",
@@ -247,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,9 +368,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:openl3]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-openl3-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -366,7 +382,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -36,6 +36,13 @@ def test_get_embedding():
     assert not np.any(np.isnan(emb1))
 
     emb1, ts1 = openl3.get_embedding(audio, sr,
+        input_repr="mel256", content_type="music", embedding_size=6144,
+        center=True, hop_size=hop_size, verbose=1)
+    assert np.all(np.abs(np.diff(ts1) - hop_size) < tol)
+    assert emb1.shape[1] == 6144
+    assert not np.any(np.isnan(emb1))
+
+    emb1, ts1 = openl3.get_embedding(audio, sr,
         input_repr="mel128", content_type="music", embedding_size=512,
         center=True, hop_size=hop_size, verbose=1)
     assert np.all(np.abs(np.diff(ts1) - hop_size) < tol)
@@ -106,12 +113,12 @@ def test_get_embedding():
     assert emb1.shape[1] == 6144
     assert not np.any(np.isnan(emb1))
 
-    emb1, ts1 = openl3.get_embedding(audio, sr,
-        input_repr="mel256", content_type="music", embedding_size=6144,
-        center=True, hop_size=hop_size, verbose=1)
-    assert np.all(np.abs(np.diff(ts1) - hop_size) < tol)
-    assert emb1.shape[1] == 6144
-    assert not np.any(np.isnan(emb1))
+    # Make sure we can load a model and pass it in
+    model = openl3.get_embedding_model("linear", "env", 6144)
+    emb1load, ts1load = openl3.get_embedding(audio, sr,
+        model=model, center=True, hop_size=hop_size, verbose=1)
+    assert np.all(np.abs(emb1load - emb1) < tol)
+    ssert np.all(np.abs(ts1load - ts1) < tol)
 
     # Make sure that the embeddings are approximately the same with mono and stereo
     audio, sr = sf.read(CHIRP_STEREO_PATH)
@@ -196,6 +203,8 @@ def test_get_embedding():
         center=True, hop_size=hop_size, verbose=0)
 
     # Make sure invalid arguments don't work
+    pytest.raises(OpenL3Error, openl3.get_embedding, audio, sr,
+        model="invalid", center=True, hop_size=0.1, verbose=1)
     pytest.raises(OpenL3Error, openl3.get_embedding, audio, sr,
         input_repr="invalid", content_type="music", embedding_size=6144,
         center=True, hop_size=0.1, verbose=1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -114,7 +114,7 @@ def test_get_embedding():
     assert not np.any(np.isnan(emb1))
 
     # Make sure we can load a model and pass it in
-    model = openl3.get_embedding_model("linear", "env", 6144)
+    model = openl3.models.get_embedding_model("linear", "env", 6144)
     emb1load, ts1load = openl3.get_embedding(audio, sr,
         model=model, center=True, hop_size=hop_size, verbose=1)
     assert np.all(np.abs(emb1load - emb1) < tol)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -118,7 +118,7 @@ def test_get_embedding():
     emb1load, ts1load = openl3.get_embedding(audio, sr,
         model=model, center=True, hop_size=hop_size, verbose=1)
     assert np.all(np.abs(emb1load - emb1) < tol)
-    ssert np.all(np.abs(ts1load - ts1) < tol)
+    assert np.all(np.abs(ts1load - ts1) < tol)
 
     # Make sure that the embeddings are approximately the same with mono and stereo
     audio, sr = sf.read(CHIRP_STEREO_PATH)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -114,7 +114,7 @@ def test_get_embedding():
     assert not np.any(np.isnan(emb1))
 
     # Make sure we can load a model and pass it in
-    model = openl3.models.get_embedding_model("linear", "env", 6144)
+    model = openl3.models.load_embedding_model("linear", "env", 6144)
     emb1load, ts1load = openl3.get_embedding(audio, sr,
         model=model, center=True, hop_size=hop_size, verbose=1)
     assert np.all(np.abs(emb1load - emb1) < tol)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,59 +1,59 @@
-from openl3.models import get_embedding_model, get_embedding_model_path
+from openl3.models import load_embedding_model, load_embedding_model_path
 
 
-def test_get_embedding_model_path():
-    embedding_model_path = get_embedding_model_path('linear', 'music')
+def test_load_embedding_model_path():
+    embedding_model_path = load_embedding_model_path('linear', 'music')
     assert '/'.join(embedding_model_path.split('/')[-2:]) == 'openl3/openl3_audio_linear_music.h5'
 
-    embedding_model_path = get_embedding_model_path('linear', 'env')
+    embedding_model_path = load_embedding_model_path('linear', 'env')
     assert '/'.join(embedding_model_path.split('/')[-2:]) == 'openl3/openl3_audio_linear_env.h5'
 
-    embedding_model_path = get_embedding_model_path('mel128', 'music')
+    embedding_model_path = load_embedding_model_path('mel128', 'music')
     assert '/'.join(embedding_model_path.split('/')[-2:]) == 'openl3/openl3_audio_mel128_music.h5'
 
-    embedding_model_path = get_embedding_model_path('mel128', 'env')
+    embedding_model_path = load_embedding_model_path('mel128', 'env')
     assert '/'.join(embedding_model_path.split('/')[-2:]) == 'openl3/openl3_audio_mel128_env.h5'
 
-    embedding_model_path = get_embedding_model_path('mel256', 'music')
+    embedding_model_path = load_embedding_model_path('mel256', 'music')
     assert '/'.join(embedding_model_path.split('/')[-2:]) == 'openl3/openl3_audio_mel256_music.h5'
 
-    embedding_model_path = get_embedding_model_path('mel256', 'env')
+    embedding_model_path = load_embedding_model_path('mel256', 'env')
     assert '/'.join(embedding_model_path.split('/')[-2:]) == 'openl3/openl3_audio_mel256_env.h5'
 
 
-def test_get_embedding_model():
-    m = get_embedding_model('linear', 'music', 6144)
+def test_load_embedding_model():
+    m = load_embedding_model('linear', 'music', 6144)
     assert m.output_shape[1] == 6144
 
-    m = get_embedding_model('linear', 'music', 512)
+    m = load_embedding_model('linear', 'music', 512)
     assert m.output_shape[1] == 512
 
-    m = get_embedding_model('linear', 'env', 6144)
+    m = load_embedding_model('linear', 'env', 6144)
     assert m.output_shape[1] == 6144
 
-    m = get_embedding_model('linear', 'env', 512)
+    m = load_embedding_model('linear', 'env', 512)
     assert m.output_shape[1] == 512
 
-    m = get_embedding_model('mel128', 'music', 6144)
+    m = load_embedding_model('mel128', 'music', 6144)
     assert m.output_shape[1] == 6144
 
-    m = get_embedding_model('mel128', 'music', 512)
+    m = load_embedding_model('mel128', 'music', 512)
     assert m.output_shape[1] == 512
 
-    m = get_embedding_model('mel128', 'env', 6144)
+    m = load_embedding_model('mel128', 'env', 6144)
     assert m.output_shape[1] == 6144
 
-    m = get_embedding_model('mel128', 'env', 512)
+    m = load_embedding_model('mel128', 'env', 512)
     assert m.output_shape[1] == 512
 
-    m = get_embedding_model('mel256', 'music', 6144)
+    m = load_embedding_model('mel256', 'music', 6144)
     assert m.output_shape[1] == 6144
 
-    m = get_embedding_model('mel256', 'music', 512)
+    m = load_embedding_model('mel256', 'music', 512)
     assert m.output_shape[1] == 512
 
-    m = get_embedding_model('mel256', 'env', 6144)
+    m = load_embedding_model('mel256', 'env', 6144)
     assert m.output_shape[1] == 6144
 
-    m = get_embedding_model('mel256', 'env', 512)
+    m = load_embedding_model('mel256', 'env', 512)
     assert m.output_shape[1] == 512


### PR DESCRIPTION
Adding the functionality to pass in a loaded model to functions that compute embeddings to avoid the model being loaded multiple times. Implemented via an optional keyword arg in `get_embedding` and `process_file`.