### PR TITLE
Update dependencies and docs to reflect current lack of support for Tensorflow 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
     - ffmpeg -hwaccels
 
 install:
-    - pip install "tensorflow>=1.12.0,<1.14.0"
+    - pip install "tensorflow>=1.12.0,<=1.15.0"
     - pip install pytest
     - pip install -e .[tests]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
     - ffmpeg -hwaccels
 
 install:
-    - pip install "tensorflow>=1.12.0,<=1.15.0"
+    - pip install "tensorflow>=1.12.0,<1.15.0"
     - pip install pytest
     - pip install -e .[tests]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
     - ffmpeg -hwaccels
 
 install:
-    - pip install "tensorflow>=1.12.0,<1.15.0"
+    - pip install "tensorflow>=1.12.0,<1.14.0"
     - pip install pytest
     - pip install -e .[tests]
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ their usecase.
 
 On most platforms, either of the following commands should properly install Tensorflow:
 
-    pip install tensorflow # CPU-only version
-    pip install tensorflow-gpu # GPU version
+    pip install "tensorflow<=1.15" # CPU-only version
+    pip install "tensorflow-gpu<1.15" # GPU version
+    
+    
+**Please note that Tensorflow 2.x is not yet supported. Ensure that an earlier version of Tensorflow is installed.** If you run into further issues with installation, a known working dependency combination is Tensorflow 1.13, Keras 2.0, and Kapre 0.1.4.
 
 For more detailed information, please consult the
 [Tensorflow installation documentation](https://www.tensorflow.org/install/).
+
 
 #### libsndfile
 OpenL3 depends on the `pysoundfile` module to load audio files, which depends on the non-Python library

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ their usecase.
 
 On most platforms, either of the following commands should properly install Tensorflow:
 
-    pip install "tensorflow<=1.15" # CPU-only version
-    pip install "tensorflow-gpu<1.15" # GPU version
+    pip install "tensorflow<1.14" # CPU-only version
+    pip install "tensorflow-gpu<1.14" # GPU version
     
     
 **Please note that Tensorflow 2.x is not yet supported. Ensure that an earlier version of Tensorflow is installed.** If you run into further issues with installation, a known working dependency combination is Tensorflow 1.13, Keras 2.0, and Kapre 0.1.4.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,13 @@
 Changelog
 ---------
 
+v0.3.1
+~~~~~~
+- Require `keras>=2.0.9,<2.3.0` in dependencies to avoid force installation of TF 2.x during pip installation.
+- Update README and installation docs to explicitly state that we do not yet support TF 2.x and to offer a working dependency combination.
+- Require `kapre==0.1.4` in dependencies to avoid installing `tensorflow>=1.14` which break regression tests.
+
+
 v0.3.0
 ~~~~~~
 - Rename audio related embedding functions to indicate that they are specific to audio.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,8 +12,8 @@ their usecase.
 
 On most platforms, either of the following commands should properly install Tensorflow:
 
->>> pip install "tensorflow<=1.15" # CPU-only version
->>> pip install "tensorflow-gpu<=1.15" # GPU version
+>>> pip install "tensorflow<1.14" # CPU-only version
+>>> pip install "tensorflow-gpu<1.14" # GPU version
 
 **Please note that Tensorflow 2.x is not yet supported. Ensure that an earlier version of Tensorflow is installed.** If you run into further issues with installation, a known working dependency combination is Tensorflow 1.13, Keras 2.0, and Kapre 0.1.4.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,8 +12,10 @@ their usecase.
 
 On most platforms, either of the following commands should properly install Tensorflow:
 
->>> pip install tensorflow # CPU-only version
->>> pip install tensorflow-gpu # GPU version
+>>> pip install "tensorflow<=1.15" # CPU-only version
+>>> pip install "tensorflow-gpu<=1.15" # GPU version
+
+**Please note that Tensorflow 2.x is not yet supported. Ensure that an earlier version of Tensorflow is installed.** If you run into further issues with installation, a known working dependency combination is Tensorflow 1.13, Keras 2.0, and Kapre 0.1.4.
 
 For more detailed information, please consult the
 `Tensorflow installation documentation <https://www.tensorflow.org/install/>`_.

--- a/openl3/version.py
+++ b/openl3/version.py
@@ -1,2 +1,2 @@
 short_version = '0.3'
-version = '0.3.0'
+version = '0.3.1'

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'keras>=2.0.9,<2.3.0',
         'numpy>=1.13.0',
         'scipy>=0.19.1',
-        'kapre>=0.1.4',
+        'kapre==0.1.4',
         'PySoundFile>=0.9.0.post1',
         'resampy>=0.2.1,<0.3.0',
         'h5py>=2.7.0,<3.0.0',

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         'Documentation': 'https://readthedocs.org/projects/openl3/'
     },
     install_requires=[
-        'keras>=2.0.9',
+        'keras>=2.0.9,<2.3.0',
         'numpy>=1.13.0',
         'scipy>=0.19.1',
         'kapre>=0.1.4',


### PR DESCRIPTION
* Pin `keras>=2.0.9,<2.3.0` to avoid force installation of TF 2.x during pip installation
* Update README and installation docs to explicitly state that we do not currently support TF 2.x and to offer a working dependency combination.