### PR TITLE
add librosa as an explicit dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,8 @@ setup(
         'resampy>=0.2.1,<0.3.0',
         'h5py>=2.7.0,<3.0.0',
         'moviepy>=1.0.0',
-        'scikit-image>=0.14.3,<0.15.0'
+        'scikit-image>=0.14.3,<0.15.0',
+        'librosa>=0.7.2',  # version limit from kapre
     ],
     extras_require={
         'docs': [


### PR DESCRIPTION
I forgot to add librosa to setup.py. 

It doesn't really make a difference because kapre still has librosa as a dependency anyways so it will still get installed without this, but I figured that it would be better form that we require it explicitly since we use it outside kapre and just in case anything changes.

I took the minimum version of librosa from kapre, but idk