### PR TITLE
Revert "Fix scikit-image<0.15.0 to fix build for Python 2.7"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         'resampy>=0.2.1,<0.3.0',
         'h5py>=2.7.0,<3.0.0',
         'moviepy>=1.0.0',
-        'scikit-image>=0.14.3,<0.15.0'
+        'scikit-image>=0.14.3'
     ],
     extras_require={
         'docs': [


### PR DESCRIPTION
OpenL3 failed to install when running on Arch Linux x64 with Python 3.8. The reason is that the scikit-image version specified (from June 2019) does not have wheels built for 3.8 (or other recent 3.x versions), and the building of the wheel failed. I found that the reason on the version restriction seems to be Py 2.7 compatibility which has since been dropped, so I reverted that commit. 

This fixes errors like the below:
```
WARNING: Discarding https://files.pythonhosted.org/packages/37/1e/26a39d9a88458eaefbab790596a19364604816e3fa5bee9618239356df50/scikit-image-0.14.5.tar.gz#sha256=1f064315cd6fb048560ac6eb03e41969aab68f9df5c145fefaece3b6823e5919 (from https://pypi.org/simple/scikit-image/) (requires-python:>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  Using cached scikit-image-0.14.3.tar.gz (27.3 MB)
    ERROR: Command errored out with exit status 1:
     command: /home/jon/.conda/envs/openl3hear/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-3s62x5vj/scikit-image_7afd5347932e447bb2dbb517d5266b86/setup.py'"'"'; __file__='"'"'/tmp/pip-install-3s62x5vj/scikit-image_7afd5347932e447bb2dbb517d5266b86/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-h_kgk_d7
         cwd: /tmp/pip-install-3s62x5vj/scikit-image_7afd5347932e447bb2dbb517d5266b86/
    Complete output (46 lines):
    Partial import of skimage during the build process.
    Traceback (most recent call last):
      File "/tmp/pip-install-3s62x5vj/scikit-image_7afd5347932e447bb2dbb517d5266b86/skimage/_build.py", line 30, in cython
        from Cython import __version__
    ModuleNotFoundError: No module named 'Cython'
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-3s62x5vj/scikit-image_7afd5347932e447bb2dbb517d5266b86/setup.py", line 111, in <module>
        setup(
      File "/home/jon/.conda/envs/openl3hear/lib/python3.8/site-packages/numpy/distutils/core.py", line 135, in setup
        config = configuration()
      File "/tmp/pip-install-3s62x5vj/scikit-image_7afd5347932e447bb2dbb517d5266b86/setup.py", line 70, in configuration
        config.add_subpackage('skimage')
      File "/home/jon/.conda/envs/openl3hear/lib/python3.8/site-packages/numpy/distutils/misc_util.py", line 1018, in add_subpackage
        config_list = self.get_subpackage(subpackage_name, subpackage_path,
      File "/home/jon/.conda/envs/openl3hear/lib/python3.8/site-packages/numpy/distutils/misc_util.py", line 984, in get_subpackage
        config = self._get_configuration_from_setup_py(
      File "/home/jon/.conda/envs/openl3hear/lib/python3.8/site-packages/numpy/distutils/misc_util.py", line 926, in _get_configuration_from_setup_py
        config = setup_module.configuration(*args)
      File "skimage/setup.py", line 14, in configuration
        config.add_subpackage('feature')
      File "/home/jon/.conda/envs/openl3hear/lib/python3.8/site-packages/numpy/distutils/misc_util.py", line 1018, in add_subpackage
        config_list = self.get_subpackage(subpackage_name, subpackage_path,
      File "/home/jon/.conda/envs/openl3hear/lib/python3.8/site-packages/numpy/distutils/misc_util.py", line 984, in get_subpackage
        config = self._get_configuration_from_setup_py(
      File "/home/jon/.conda/envs/openl3hear/lib/python3.8/site-packages/numpy/distutils/misc_util.py", line 926, in _get_configuration_from_setup_py
        config = setup_module.configuration(*args)
      File "skimage/feature/setup.py", line 22, in configuration
        cython(['_haar.pyx'], working_path=base_path)
      File "/tmp/pip-install-3s62x5vj/scikit-image_7afd5347932e447bb2dbb517d5266b86/skimage/_build.py", line 41, in cython
        raise RuntimeError('Cython >= %s is required to build scikit-image from git checkout' \
    RuntimeError: Cython >= 0.23.4 is required to build scikit-image from git checkout
    Cython >= 0.23.4 not found; falling back to pre-built geometry.c
    Cython >= 0.23.4 not found; falling back to pre-built transform.c
    Cython >= 0.23.4 not found; falling back to pre-built interpolation.c
    Cython >= 0.23.4 not found; falling back to pre-built _draw.c
    Cython >= 0.23.4 not found; falling back to pre-built corner_cy.c
    Cython >= 0.23.4 not found; falling back to pre-built censure_cy.c
    Cython >= 0.23.4 not found; falling back to pre-built orb_cy.c
    Cython >= 0.23.4 not found; falling back to pre-built brief_cy.c
    Cython >= 0.23.4 not found; falling back to pre-built _texture.c
    Cython >= 0.23.4 not found; falling back to pre-built _hessian_det_appx.c
    Cython >= 0.23.4 not found; falling back to pre-built _hoghistogram.c
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/36/ae/7988e65bb8accb894ffb3ed97ff572f9f85eacc737c03cd954b89809ca49/scikit-image-0.14.3.tar.gz#sha256=f05eab2df885fb6fde3df0e4d24c9c620d6474ea0eb949fd45f6f634925dd514 (from https://pypi.org/simple/scikit-image/) (requires-python:>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
INFO: pip is looking at multiple versions of <Python from Requires-Python> to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of cython to determine which version is compatible with other requirements. This could take a while.
ERROR: Could not find a version that satisfies the requirement scikit-image<0.15.0,>=0.14.3 (from openl3) (from versions: 0.7.2, 0.8.0, 0.8.1, 0.8.2, 0.9.0, 0.9.1, 0.9.3, 0.10.0, 0.10.1, 0.11.2, 0.11.3, 0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.13.0, 0.13.1, 0.14.0, 0.14.1, 0.14.2, 0.14.3, 0.14.5, 0.15.0, 0.16.2, 0.17.1, 0.17.2, 0.18.0rc0, 0.18.0rc1, 0.18.0rc2, 0.18.0, 0.18.1, 0.18.2rc1, 0.18.2rc2, 0.18.2)
ERROR: No matching distribution found for scikit-image<0.15.0,>=0.14.3
```
