### PR TITLE
Fix issues related to upgrading scikit-image

### DIFF
--- a/openl3/core.py
+++ b/openl3/core.py
@@ -481,7 +481,10 @@ def _preprocess_image_batch(image):
         for idx, frame in enumerate(image):
             # Only reshape if image is larger than 256x256
             if min(frame.shape[0], frame.shape[1]) > 256:
-                frame = skimage.transform.rescale(frame, scaling)
+                try:
+                    frame = skimage.transform.rescale(frame, scaling, channel_axis=-1)
+                except TypeError:
+                    frame = skimage.transform.rescale(frame, scaling, multichannel=True)
             x1, x2 = frame.shape[:-1]
             startx1 = x1//2-(224//2)
             startx2 = x2//2-(224//2)

--- a/openl3/core.py
+++ b/openl3/core.py
@@ -449,6 +449,7 @@ def _preprocess_image_batch(image):
         4d numpy array of image data.
     """
     import skimage
+    import skimage.transform
     if image.size == 0:
         raise OpenL3Error('Got empty image')
 
@@ -679,7 +680,7 @@ def process_image_file(filepath, output_dir=None, suffix=None, model=None,
     -------
 
     """
-    import skimage
+    import skimage.io
     if isinstance(filepath, str):
         filepath_list = [filepath]
     elif isinstance(filepath, list):

--- a/openl3/core.py
+++ b/openl3/core.py
@@ -483,22 +483,22 @@ def _preprocess_image_batch(image):
             if min(frame.shape[0], frame.shape[1]) > 256:
                 try:
                     frame = skimage.transform.rescale(frame, scaling,
-                                                      order=1,
-                                                      mode='reflect',
+                                                      mode='constant',
+                                                      cval=0,
                                                       clip=True,
                                                       preserve_range=False,
                                                       channel_axis=-1,
-                                                      anti_aliasing=None,
+                                                      anti_aliasing=False,
                                                       anti_aliasing_sigma=None)
                 except TypeError:
                     frame = skimage.transform.rescale(frame, scaling,
-                                                      order=1,
-                                                      mode='reflect',
+                                                      mode='constant',
+                                                      cval=0,
                                                       clip=True,
                                                       preserve_range=False,
                                                       multichannel=True,
-                                                      anti_aliasing = None,
-                                                      anti_aliasing_sigma = None)
+                                                      anti_aliasing=False,
+                                                      anti_aliasing_sigma=None)
             x1, x2 = frame.shape[:-1]
             startx1 = x1//2-(224//2)
             startx2 = x2//2-(224//2)

--- a/openl3/core.py
+++ b/openl3/core.py
@@ -482,9 +482,23 @@ def _preprocess_image_batch(image):
             # Only reshape if image is larger than 256x256
             if min(frame.shape[0], frame.shape[1]) > 256:
                 try:
-                    frame = skimage.transform.rescale(frame, scaling, channel_axis=-1)
+                    frame = skimage.transform.rescale(frame, scaling,
+                                                      order=1,
+                                                      mode='reflect',
+                                                      clip=True,
+                                                      preserve_range=False,
+                                                      channel_axis=-1,
+                                                      anti_aliasing=None,
+                                                      anti_aliasing_sigma=None)
                 except TypeError:
-                    frame = skimage.transform.rescale(frame, scaling, multichannel=True)
+                    frame = skimage.transform.rescale(frame, scaling,
+                                                      order=1,
+                                                      mode='reflect',
+                                                      clip=True,
+                                                      preserve_range=False,
+                                                      multichannel=True,
+                                                      anti_aliasing = None,
+                                                      anti_aliasing_sigma = None)
             x1, x2 = frame.shape[:-1]
             startx1 = x1//2-(224//2)
             startx2 = x2//2-(224//2)


### PR DESCRIPTION
- Import `skimage` modules explicitly since `skimage` uses lazy imports
- Update arguments to `skimage.transform.rescale`. Default argument values have changed, so they have been set to be consistent to `skimage>=0.14.3,<0.15.0`

Address #73 