### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ else:
 
 version = imp.load_source('openl3.version', os.path.join('openl3', 'version.py'))
 
-with open('README.md') as file:
+with open('README.md',encoding='utf8') as file:
     long_description = file.read()
 
 setup(


### PR DESCRIPTION
should open 'README.md' with utf-8,because the system default encoding may not be that,which makes the installation process fail.