### PR TITLE
Add missing comma to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         'resampy>=0.2.1,<0.3.0',
         'h5py>=2.7.0,<3.0.0',
         'moviepy>=1.0.0',
-        'scikit-image>=0.14.3'
+        'scikit-image>=0.14.3',
         'librosa>=0.7.2',  # version limit from kapre
     ],
     extras_require={


### PR DESCRIPTION
This took me a minute to track down, but there was a missing comma in setup.py that was causing my conda environment spec to break.

Without the comma, the dependencies for scikit-image and librosa run together into a single string, so you get `"scikit-image >= 0.14.3librosa>=0.7.2"` and everything blows up.