### PR TITLE
Update `Iterable` import to support Python>=3.3

### DIFF
--- a/openl3/cli.py
+++ b/openl3/cli.py
@@ -4,7 +4,10 @@ from openl3 import process_audio_file, process_image_file, process_video_file
 from openl3.models import load_audio_embedding_model, load_image_embedding_model
 from openl3.openl3_exceptions import OpenL3Error
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, ArgumentTypeError
-from collections import Iterable
+try: # python>=3.3
+    from collections.abc import Iterable
+except:
+    from collections import Iterable
 
 
 def positive_float(value):

--- a/tests/generate_openl3_regression_data.py
+++ b/tests/generate_openl3_regression_data.py
@@ -6,9 +6,12 @@ from openl3 import process_audio_file, process_image_file, process_video_file
 from openl3.models import load_audio_embedding_model, load_image_embedding_model
 from openl3.openl3_exceptions import OpenL3Error
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, ArgumentTypeError
-from collections import Iterable
 from six import string_types
 import numpy as np
+try: # python>=3.3
+    from collections.abc import Iterable
+except:
+    from collections import Iterable
 
 
 def positive_float(value):


### PR DESCRIPTION
Whe running with CLI on Python>3.3, an error will be raised:

```
ImportError: cannot import name 'Iterable' from 'collections' (.../collections/__init__.py)
```

## Cause

[Introduced in python 3.3](https://docs.python.org/3/library/collections.abc.html?highlight=iterable#collections.abc.Iterable), the previous `collections.Iterable` is removed.

## Potential Fix

- Use [six](https://pypi.org/project/six/) to provide an extra compatibility layer over type hints (with `collection_abc`)
- Use the quick fix of a try except block

## Commit Info

The latter solution is used for the sake of simplicity. 

## Tests

(🟢 this commit has no breaking changes and is a minor patch.)
